### PR TITLE
Rename signatureTextEncoding to signatureFormat

### DIFF
--- a/webhooks-ts/openapi.yaml
+++ b/webhooks-ts/openapi.yaml
@@ -21,7 +21,7 @@ x-speakeasy-webhooks:
   security:
     type: signature
     headerName: x-signature
-    signatureTextEncoding: base64
+    signatureFormat: base64
     algorithm: hmac-sha256
 webhooks:
   pet.created:


### PR DESCRIPTION
update the key naming to meet the latest version of the generator's specification